### PR TITLE
Update clarify the concept of Sequence Numbers

### DIFF
--- a/doc_source/key-concepts.md
+++ b/doc_source/key-concepts.md
@@ -50,7 +50,7 @@ A *partition key* is used to group data by shard within a stream\. The Kinesis D
 
 ### Sequence Numbers<a name="sequence-number"></a>
 
-Each data record has a sequence number that is unique within its shard\. The sequence number is assigned by Kinesis Data Streams after you write to the stream with `client.putRecords` or `client.putRecord`\. Sequence numbers for the same partition key generally increase over time; the longer the time period between write requests, the larger the sequence numbers become\.
+Each data record has a sequence number that is unique per partition-key within its shard\. The sequence number is assigned by Kinesis Data Streams after you write to the stream with `client.putRecords` or `client.putRecord`\. Sequence numbers for the same partition key generally increase over time; the longer the time period between write requests, the larger the sequence numbers become\.
 
 **Note**  
 Sequence numbers cannot be used as indexes to sets of data within the same stream\. To logically separate sets of data, use partition keys or create a separate stream for each dataset\.


### PR DESCRIPTION
Sequence numbers are unique per shard by partition key. Original documentation was unclear that the same shard could have the same sequence number for different partition keys.

*Issue #, if available: None

*Description of changes: Updated to include the text per partition-key.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
