### PR TITLE
Fix misspelled word excecutor -> executor

### DIFF
--- a/doc_source/building-enhanced-consumers-kcl-java.md
+++ b/doc_source/building-enhanced-consumers-kcl-java.md
@@ -135,7 +135,7 @@ public class SampleSingle {
             log.error("Caught exception while waiting for confirm. Shutting down.", ioex);
         }
 
-        log.info("Cancelling producer, and shutting down excecutor.");
+        log.info("Cancelling producer, and shutting down executor.");
         producerFuture.cancel(true);
         producerExecutor.shutdownNow();
 

--- a/doc_source/kcl2-standard-consumer-java-example.md
+++ b/doc_source/kcl2-standard-consumer-java-example.md
@@ -116,7 +116,7 @@ public class SampleSingle {
             log.error("Caught exception while waiting for confirm. Shutting down.", ioex);
         }
 
-        log.info("Cancelling producer and shutting down excecutor.");
+        log.info("Cancelling producer and shutting down executor.");
         producerFuture.cancel(true);
         producerExecutor.shutdownNow();
 


### PR DESCRIPTION
*Description of changes:*
Fix misspelled word "excecutor" -> "executor"

I just noticed this [in the docs](https://docs.aws.amazon.com/streams/latest/dev/building-enhanced-consumers-kcl-java.html), and wanted to submit a PR to correct it. 🙂

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
