### PR TITLE
Update asynchronous example

### DIFF
--- a/doc_source/kinesis-kpl-writing.md
+++ b/doc_source/kinesis-kpl-writing.md
@@ -70,6 +70,6 @@ for (int i = 0; i < 100; ++i) {
     ByteBuffer data = ByteBuffer.wrap("myData".getBytes("UTF-8"));      
     ListenableFuture<UserRecordResult> f = kinesis.addUserRecord("myStream", "myPartitionKey", data);     
     // If the Future is complete by the time we call addCallback, the callback will be invoked immediately.
-    Futures.addCallback(f, myCallback); 
+    Futures.addCallback(f, myCallback, MoreExecutors.directExecutor()); 
 }
 ```


### PR DESCRIPTION
The original method in the example is now deprecated in Guava: https://guava.dev/releases/23.0/api/docs/com/google/common/util/concurrent/Futures.html#addCallback-com.google.common.util.concurrent.ListenableFuture-com.google.common.util.concurrent.FutureCallback-

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
